### PR TITLE
chore: update .gitignore to exclude build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Thumbs.db
 
 # Poetry
 poetry.lock
+
+# Build
+build/
+dist/


### PR DESCRIPTION
Add build/ and dist/ directories to .gitignore to prevent build
artifacts from being tracked. This keeps the repository clean and
avoids committing unnecessary files generated during packaging.