### PR TITLE
chore: add metadata to pyproject.toml for project info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,22 @@ description = "A coroutine composition framework for declarative async pipelines
 authors = ["Shiv <shiv@zerobytes.fr>"]
 license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/shivkun/corstream"
+repository = "https://github.com/shivkun/corstream"
+documentation = "https://github.com/shivkun/corstream#readme"
+keywords = ["asyncio", "streams", "pipelines", "functional", "couroutines", "declarative"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed"
+]
 packages = [{ include = "corstream" }]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://github.com/shivkun/corstream"
 repository = "https://github.com/shivkun/corstream"
 documentation = "https://github.com/shivkun/corstream#readme"
-keywords = ["asyncio", "streams", "pipelines", "functional", "couroutines", "declarative"]
+keywords = ["asyncio", "streams", "pipelines", "functional", "coroutines", "declarative"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Include homepage, repository, and documentation URLs to improve
project discoverability. Add keywords and classifiers to specify
development status, audience, license, supported Python versions,
and topics. These changes enhance package metadata for publishing
and indexing on package repositories.