### PR TITLE
chore: bump version to 0.1.0a1 for initial alpha release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "corstream"
-version = "0.1.0"
+version = "0.1.0a1"
 description = "A coroutine composition framework for declarative async pipelines in Python"
 authors = ["Shiv <shiv@zerobytes.fr>"]
 license = "MIT"


### PR DESCRIPTION
Update the project version in pyproject.toml to 0.1.0a1 to mark
the first alpha release. This change signals the start of early
testing and feedback collection for the coroutine composition
framework.