### PR TITLE
chore: update copyright holder in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 [fullname]
+Copyright (c) 2025 Shiv and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Change the copyright holder from a placeholder to the actual
name "Shiv and contributors" to accurately reflect ownership and
contributions for the 2025 license year.