### PR TITLE
fix: correct async stream method parameters and type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ from corstream import Stream
 async def get_email(user_id: int) -> str:
     return f"user{user_id}@example.com"
 
-async def send_batch(batch: list[str]):
+async def send_batch(batch: list[str]) -> None:
     print("Sending:", batch)
 
 await (
     Stream
     .from_iterable(range(1, 11))
     .filter(lambda x: x % 2 == 0)
-    .map_async(get_email, max_concurrency=3)
+    .map_async(get_email, max_concurrent=3)
     .batch(5)
-    .log("batch")
+    .log(label="batch")
     .for_each(send_batch)
 )
 ```


### PR DESCRIPTION
Update send_batch function to include a return type annotation for clarity.
Fix parameter name from max_concurrency to max_concurrent in map_async call
to match the expected argument and avoid runtime errors.
Change log method call to use a keyword argument for label to improve
readability and maintain consistency with the API.